### PR TITLE
EG 06.06 + `len()` and `is_empty()` for `<Spam/GPT>DataLoader` structs

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -76,6 +76,7 @@ static EXAMPLE_REGISTRY: LazyLock<HashMap<&'static str, Box<dyn Example>>> = Laz
     m.insert("06.03", Box::new(examples::ch06::EG03));
     m.insert("06.04", Box::new(examples::ch06::EG04));
     m.insert("06.05", Box::new(examples::ch06::EG05));
+    m.insert("06.06", Box::new(examples::ch06::EG06));
     m
 });
 

--- a/src/examples/ch06.rs
+++ b/src/examples/ch06.rs
@@ -397,9 +397,9 @@ impl Example for EG06 {
         println!("Label batch dimensions: {:?}", target_batch.shape());
 
         // print total number of batches in each data loader
-        // println!("{:?} training batches", train_loader.batcher().count());
-        // println!("{:?} validation batches", val_loader.batcher().count());
-        println!("{:?} test batches", test_loader.batcher().count());
+        println!("{:?} training batches", train_loader.len());
+        println!("{:?} validation batches", val_loader.len());
+        println!("{:?} test batches", test_loader.len());
 
         Ok(())
     }

--- a/src/listings/ch06.rs
+++ b/src/listings/ch06.rs
@@ -549,6 +549,27 @@ impl SpamDataLoader {
             .batch_size(self.batch_size)
             .return_last_incomplete_batch(!self.drop_last)
     }
+
+    pub fn len(&self) -> usize {
+        if self.drop_last {
+            self.batcher().count()
+        } else {
+            // There is a bug in candle_datasets::Batcher, such that if
+            // return_last_incomplete_batch is set to true, then the iterator
+            // will never return None. This breaks `Iterator.count()` which consumes
+            // the iterator until a None is encountered.
+            let mut batcher = self.batcher();
+            let mut count = 0_usize;
+            while let Some(Ok(_el)) = batcher.next() {
+                count += 1;
+            }
+            count
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        (self.dataset.len() < self.batch_size) && (self.drop_last)
+    }
 }
 
 #[cfg(test)]
@@ -695,16 +716,19 @@ mod tests {
         let spam_dataset = SpamDataset::new(df, &tokenizer, Some(max_length), PAD_TOKEN_ID);
         let batch_size = 2_usize;
         let shuffle = false;
-        let drop_last = true;
+        let drop_last = false;
         let data_loader = SpamDataLoader::new(spam_dataset, batch_size, shuffle, drop_last);
 
         let mut batcher = data_loader.batcher();
+        let mut count = 0_usize;
         while let Some(Ok((inputs, targets))) = batcher.next() {
-            assert_eq!(inputs.dims()[0], batch_size);
-            assert_eq!(targets.dims()[0], batch_size);
+            assert!(inputs.dims()[0] <= batch_size);
+            assert!(targets.dims()[0] <= batch_size);
             assert_eq!(inputs.dims()[1], max_length);
             assert_eq!(targets.dims()[1], 1_usize);
+            count += 1;
         }
+        assert_eq!(data_loader.len(), count);
         Ok(())
     }
 }

--- a/src/listings/ch06.rs
+++ b/src/listings/ch06.rs
@@ -729,6 +729,7 @@ mod tests {
             count += 1;
         }
         assert_eq!(data_loader.len(), count);
+        assert!(!data_loader.is_empty());
         Ok(())
     }
 }


### PR DESCRIPTION
- Implemented `len()` since there is a bug in current implementation of `candle_datasets::Batcher` where `next` doesn't return a None 