### PR TITLE
Ex 6.3 + necessary re-factor to intro `custom_pred_token_index`

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -30,6 +30,7 @@ static EXERCISE_REGISTRY: LazyLock<HashMap<&'static str, Box<dyn Exercise>>> =
         // ch06
         m.insert("6.1", Box::new(exercises::ch06::X1));
         m.insert("6.2", Box::new(exercises::ch06::X2));
+        m.insert("6.3", Box::new(exercises::ch06::X3));
         m
     });
 

--- a/src/examples/ch06.rs
+++ b/src/examples/ch06.rs
@@ -747,9 +747,12 @@ impl Example for EG11 {
 
         // compute accuracies
         let num_batches = Some(10_usize);
-        let train_accuracy = calc_accuracy_loader(&train_loader, &model, vb.device(), num_batches)?;
-        let val_accuracy = calc_accuracy_loader(&val_loader, &model, vb.device(), num_batches)?;
-        let test_accuracy = calc_accuracy_loader(&test_loader, &model, vb.device(), num_batches)?;
+        let train_accuracy =
+            calc_accuracy_loader(&train_loader, &model, vb.device(), num_batches, None)?;
+        let val_accuracy =
+            calc_accuracy_loader(&val_loader, &model, vb.device(), num_batches, None)?;
+        let test_accuracy =
+            calc_accuracy_loader(&test_loader, &model, vb.device(), num_batches, None)?;
 
         println!("Training accuracy: {}", train_accuracy);
         println!("Validation accuracy: {}", val_accuracy);
@@ -813,9 +816,9 @@ impl Example for EG12 {
 
         // compute accuracies
         let num_batches = Some(5_usize);
-        let train_loss = calc_loss_loader(&train_loader, &model, vb.device(), num_batches)?;
-        let val_loss = calc_loss_loader(&val_loader, &model, vb.device(), num_batches)?;
-        let test_loss = calc_loss_loader(&test_loader, &model, vb.device(), num_batches)?;
+        let train_loss = calc_loss_loader(&train_loader, &model, vb.device(), num_batches, None)?;
+        let val_loss = calc_loss_loader(&val_loader, &model, vb.device(), num_batches, None)?;
+        let test_loss = calc_loss_loader(&test_loader, &model, vb.device(), num_batches, None)?;
 
         println!("Training loss: {}", train_loss);
         println!("Validation loss: {}", val_loss);
@@ -911,6 +914,7 @@ impl Example for EG13 {
             num_epochs,
             eval_freq,
             eval_iter,
+            None,
         );
 
         // save model
@@ -980,9 +984,12 @@ impl Example for EG14 {
 
         // compute accuracies
         let num_batches = None;
-        let train_accuracy = calc_accuracy_loader(&train_loader, &model, vb.device(), num_batches)?;
-        let val_accuracy = calc_accuracy_loader(&val_loader, &model, vb.device(), num_batches)?;
-        let test_accuracy = calc_accuracy_loader(&test_loader, &model, vb.device(), num_batches)?;
+        let train_accuracy =
+            calc_accuracy_loader(&train_loader, &model, vb.device(), num_batches, None)?;
+        let val_accuracy =
+            calc_accuracy_loader(&val_loader, &model, vb.device(), num_batches, None)?;
+        let test_accuracy =
+            calc_accuracy_loader(&test_loader, &model, vb.device(), num_batches, None)?;
 
         println!("Training accuracy: {}", train_accuracy);
         println!("Validation accuracy: {}", val_accuracy);

--- a/src/exercises/ch06.rs
+++ b/src/exercises/ch06.rs
@@ -146,14 +146,18 @@ impl Exercise for X1 {
             num_epochs,
             eval_freq,
             eval_iter,
+            None,
         );
 
         println!("Computing performance metrics");
         // compute accuracies
         let num_batches = None;
-        let train_accuracy = calc_accuracy_loader(&train_loader, &model, vb.device(), num_batches)?;
-        let val_accuracy = calc_accuracy_loader(&val_loader, &model, vb.device(), num_batches)?;
-        let test_accuracy = calc_accuracy_loader(&test_loader, &model, vb.device(), num_batches)?;
+        let train_accuracy =
+            calc_accuracy_loader(&train_loader, &model, vb.device(), num_batches, None)?;
+        let val_accuracy =
+            calc_accuracy_loader(&val_loader, &model, vb.device(), num_batches, None)?;
+        let test_accuracy =
+            calc_accuracy_loader(&test_loader, &model, vb.device(), num_batches, None)?;
 
         println!("Training accuracy: {}", train_accuracy);
         println!("Validation accuracy: {}", val_accuracy);
@@ -238,14 +242,18 @@ impl Exercise for X2 {
             num_epochs,
             eval_freq,
             eval_iter,
+            None,
         );
 
         println!("Computing performance metrics");
         // compute accuracies
         let num_batches = None;
-        let train_accuracy = calc_accuracy_loader(&train_loader, &model, vb.device(), num_batches)?;
-        let val_accuracy = calc_accuracy_loader(&val_loader, &model, vb.device(), num_batches)?;
-        let test_accuracy = calc_accuracy_loader(&test_loader, &model, vb.device(), num_batches)?;
+        let train_accuracy =
+            calc_accuracy_loader(&train_loader, &model, vb.device(), num_batches, None)?;
+        let val_accuracy =
+            calc_accuracy_loader(&val_loader, &model, vb.device(), num_batches, None)?;
+        let test_accuracy =
+            calc_accuracy_loader(&test_loader, &model, vb.device(), num_batches, None)?;
 
         println!("Training accuracy: {}", train_accuracy);
         println!("Validation accuracy: {}", val_accuracy);

--- a/src/exercises/ch06.rs
+++ b/src/exercises/ch06.rs
@@ -231,7 +231,7 @@ impl Exercise for X2 {
             },
         )?;
 
-        println!("Fine-tuning GPT2 on spam training dataset");
+        println!("Fine-tuning ENTIRE GPT2 on spam training dataset");
         let (eval_freq, eval_iter, num_epochs) = (50_usize, 5_usize, 5_usize);
         let _ = train_classifier_simple(
             &model,
@@ -325,9 +325,6 @@ impl Exercise for X3 {
             .keys()
             .filter(|k| k.contains("final_norm") || k.contains("out_head") || k.contains("trf.11"))
             .collect();
-
-        println!("Training variables: {:?}\n", var_names);
-
         for var_name in var_names.into_iter() {
             let var = tensor_data.get(var_name).unwrap();
             training_vars.push(var.clone());
@@ -343,6 +340,7 @@ impl Exercise for X3 {
             },
         )?;
 
+        println!("Fine-tuning GPT2 on spam training dataset using first-token");
         let (eval_freq, eval_iter, num_epochs) = (50_usize, 5_usize, 5_usize);
         let custom_pred_token_index = Some(0_usize); // use the first token!
         let _ = train_classifier_simple(

--- a/src/exercises/ch06.rs
+++ b/src/exercises/ch06.rs
@@ -262,3 +262,130 @@ impl Exercise for X2 {
         Ok(())
     }
 }
+
+/// # Fine-tuning the first vs. last token
+///
+/// #### Id
+/// 6.3
+///
+/// #### CLI command
+/// ```sh
+/// # without cuda
+/// cargo run exercise 6.3
+///
+/// # with cuda
+/// cargo run --features cuda exercise 6.3
+/// ```
+pub struct X3;
+
+impl Exercise for X3 {
+    fn name(&self) -> String {
+        "6.3".to_string()
+    }
+
+    fn title(&self) -> String {
+        "Fine-tuning the first vs. last token".to_string()
+    }
+
+    fn statement(&self) -> String {
+        let stmt = "Try fine-tuning the first output token. Notice the \
+        changes in predictive performance compared to fine-tuning the last \
+        output token.";
+        stmt.to_string()
+    }
+
+    fn main(&self) -> Result<()> {
+        use crate::listings::{
+            ch04::Config,
+            ch06::{
+                calc_accuracy_loader, download_and_load_gpt2, modify_out_head_for_classification,
+                train_classifier_simple, HF_GPT2_MODEL_ID,
+            },
+        };
+        use candle_core::{DType, Device, Var};
+        use candle_nn::{AdamW, Optimizer, ParamsAdamW, VarBuilder, VarMap};
+
+        // get gpt model with classification head
+        let mut cfg = Config::gpt2_124m();
+        cfg.qkv_bias = true;
+        let varmap = VarMap::new();
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &Device::cuda_if_available(0)?);
+        let mut model = download_and_load_gpt2(&varmap, vb.pp("model"), cfg, HF_GPT2_MODEL_ID)?;
+        modify_out_head_for_classification(&mut model, cfg, 2_usize, &varmap, vb.pp("model"))?;
+
+        // get data loaders
+        let eg06 = crate::examples::ch06::EG06; // re-use
+        let (train_loader, val_loader, test_loader) = eg06.main_with_return(false)?;
+
+        // trainable params and optimizer
+        // trainable: last trf block, final layer norm, classification head
+        let mut training_vars: Vec<Var> = vec![];
+        let tensor_data = varmap.data().lock().unwrap();
+        let var_names: Vec<&String> = tensor_data
+            .keys()
+            .filter(|k| k.contains("final_norm") || k.contains("out_head") || k.contains("trf.11"))
+            .collect();
+
+        println!("Training variables: {:?}\n", var_names);
+
+        for var_name in var_names.into_iter() {
+            let var = tensor_data.get(var_name).unwrap();
+            training_vars.push(var.clone());
+        }
+        drop(tensor_data);
+
+        let optimizer = AdamW::new(
+            training_vars,
+            ParamsAdamW {
+                lr: 5e-5,
+                weight_decay: 0.1,
+                ..Default::default()
+            },
+        )?;
+
+        let (eval_freq, eval_iter, num_epochs) = (50_usize, 5_usize, 5_usize);
+        let custom_pred_token_index = Some(0_usize); // use the first token!
+        let _ = train_classifier_simple(
+            &model,
+            &train_loader,
+            &val_loader,
+            optimizer,
+            vb.device(),
+            num_epochs,
+            eval_freq,
+            eval_iter,
+            custom_pred_token_index,
+        );
+
+        println!("Computing performance metrics");
+        // compute accuracies
+        let num_batches = None;
+        let train_accuracy = calc_accuracy_loader(
+            &train_loader,
+            &model,
+            vb.device(),
+            num_batches,
+            custom_pred_token_index,
+        )?;
+        let val_accuracy = calc_accuracy_loader(
+            &val_loader,
+            &model,
+            vb.device(),
+            num_batches,
+            custom_pred_token_index,
+        )?;
+        let test_accuracy = calc_accuracy_loader(
+            &test_loader,
+            &model,
+            vb.device(),
+            num_batches,
+            custom_pred_token_index,
+        )?;
+
+        println!("Training accuracy: {}", train_accuracy);
+        println!("Validation accuracy: {}", val_accuracy);
+        println!("Test accuracy: {}", test_accuracy);
+
+        Ok(())
+    }
+}

--- a/src/listings/ch06.rs
+++ b/src/listings/ch06.rs
@@ -825,9 +825,20 @@ pub fn train_classifier_simple<T: Optimizer>(
             global_step += 1;
         }
 
-        let train_accuracy =
-            calc_accuracy_loader(train_loader, model, device, Some(eval_iter), None)?;
-        let val_accuracy = calc_accuracy_loader(val_loader, model, device, Some(eval_iter), None)?;
+        let train_accuracy = calc_accuracy_loader(
+            train_loader,
+            model,
+            device,
+            Some(eval_iter),
+            custom_pred_token_index,
+        )?;
+        let val_accuracy = calc_accuracy_loader(
+            val_loader,
+            model,
+            device,
+            Some(eval_iter),
+            custom_pred_token_index,
+        )?;
         println!("Training accuracy: {}", train_accuracy);
         println!("Validation accuracy: {}", val_accuracy);
         train_accs.push(train_accuracy);

--- a/src/listings/ch06.rs
+++ b/src/listings/ch06.rs
@@ -654,7 +654,7 @@ pub fn calc_num_correct_batch(
     target_batch: &Tensor,
     model: &GPTModel,
     device: &Device,
-    custom_pred_token_index: Option<usize>,
+    custom_pred_token_index: Option<usize>, // introduced for Exercise 6.3
 ) -> Result<Tensor> {
     let input_batch = input_batch.to_device(device)?;
     let target_batch = target_batch.to_device(device)?.to_dtype(DType::U32)?;
@@ -678,7 +678,7 @@ pub fn calc_accuracy_loader(
     model: &GPTModel,
     device: &Device,
     num_batches: Option<usize>,
-    custom_pred_token_index: Option<usize>,
+    custom_pred_token_index: Option<usize>, // introduced for Exercise 6.3
 ) -> Result<f32> {
     let mut correct_predictions = 0_usize;
     let mut num_examples = 0_usize;


### PR DESCRIPTION
To use the first-token as logits, we need to introduce `custom_pred_token_index` in necessary functions.