### PR TITLE
EG 07.09 + re-factor of `ch05::calc_loss_loader` to use new `DataLoader` trait

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -99,6 +99,7 @@ static EXAMPLE_REGISTRY: LazyLock<HashMap<&'static str, Box<dyn Example>>> = Laz
     m.insert("07.06", Box::new(examples::ch07::EG06));
     m.insert("07.07", Box::new(examples::ch07::EG07));
     m.insert("07.08", Box::new(examples::ch07::EG08));
+    m.insert("07.09", Box::new(examples::ch07::EG09));
     m
 });
 

--- a/src/examples/ch02.rs
+++ b/src/examples/ch02.rs
@@ -150,7 +150,7 @@ pub struct EG04;
 
 impl Example for EG04 {
     fn description(&self) -> String {
-        String::from("Create absolute postiional embeddings.")
+        String::from("Create absolute positional embeddings.")
     }
 
     fn page_source(&self) -> usize {
@@ -158,7 +158,7 @@ impl Example for EG04 {
     }
 
     fn main(&self) -> Result<()> {
-        use crate::listings::ch02::create_dataloader_v1;
+        use crate::listings::ch02::{create_dataloader_v1, DataLoader};
         use candle_core::{DType, Tensor};
         use candle_nn::{embedding, VarBuilder, VarMap};
         use std::fs;

--- a/src/examples/ch05.rs
+++ b/src/examples/ch05.rs
@@ -206,6 +206,8 @@ impl Example for EG03 {
     }
 
     fn main(&self) -> Result<()> {
+        use crate::listings::ch02::DataLoader;
+
         let (train_loader, val_loader) = addons::get_train_val_data_loaders(true)?;
 
         let mut train_batcher = train_loader.batcher();

--- a/src/exercises/ch02.rs
+++ b/src/exercises/ch02.rs
@@ -82,7 +82,7 @@ impl Exercise for X2 {
     }
 
     fn main(&self) -> Result<()> {
-        use crate::listings::ch02::create_dataloader_v1;
+        use crate::listings::ch02::{create_dataloader_v1, DataLoader};
         use std::fs;
 
         let raw_text = fs::read_to_string("data/the-verdict.txt").expect("Unable to read the file");

--- a/src/listings/ch02.rs
+++ b/src/listings/ch02.rs
@@ -326,6 +326,28 @@ pub struct GPTDataLoader {
     drop_last: bool,
 }
 
+/// A DataLoader trait
+///
+/// NOTE: Was introduced in ch07 since we wanted to re-use the methods here and
+/// those introduced in ch05, namely `calc_loss_loader`.
+pub trait DataLoader {
+    type Item;
+
+    fn batcher(&self) -> Self::Item;
+}
+
+impl DataLoader for GPTDataLoader {
+    type Item = GPTDataBatcher;
+    /// Returns a `GPTDataBatcher` that itself provides batches over the
+    /// associated dataset.
+    fn batcher(&self) -> GPTDataBatcher {
+        let iter = GPTDatasetIter::new(self.dataset.clone(), self.shuffle);
+        Batcher::new_r2(iter)
+            .batch_size(self.batch_size)
+            .return_last_incomplete_batch(!self.drop_last)
+    }
+}
+
 impl GPTDataLoader {
     /// Creates a new GPTDataLoader.
     ///
@@ -351,15 +373,6 @@ impl GPTDataLoader {
             shuffle,
             drop_last,
         }
-    }
-
-    /// Returns a `GPTDataBatcher` that itself provides batches over the
-    /// associated dataset.
-    pub fn batcher(&self) -> GPTDataBatcher {
-        let iter = GPTDatasetIter::new(self.dataset.clone(), self.shuffle);
-        Batcher::new_r2(iter)
-            .batch_size(self.batch_size)
-            .return_last_incomplete_batch(!self.drop_last)
     }
 
     pub fn len(&self) -> usize {

--- a/src/listings/ch02.rs
+++ b/src/listings/ch02.rs
@@ -331,13 +331,13 @@ pub struct GPTDataLoader {
 /// NOTE: Was introduced in ch07 since we wanted to re-use the methods here and
 /// those introduced in ch05, namely `calc_loss_loader`.
 pub trait DataLoader {
-    type Item;
+    type Batcher;
 
-    fn batcher(&self) -> Self::Item;
+    fn batcher(&self) -> Self::Batcher;
 }
 
 impl DataLoader for GPTDataLoader {
-    type Item = GPTDataBatcher;
+    type Batcher = GPTDataBatcher;
     /// Returns a `GPTDataBatcher` that itself provides batches over the
     /// associated dataset.
     fn batcher(&self) -> GPTDataBatcher {

--- a/src/listings/ch05.rs
+++ b/src/listings/ch05.rs
@@ -3,7 +3,7 @@
 use crate::{
     candle_addons::TopK,
     listings::{
-        ch02::GPTDataLoader,
+        ch02::{DataLoader, GPTDataLoader},
         ch04::{generate_text_simple, GPTModel},
     },
 };
@@ -86,9 +86,11 @@ pub fn calc_loss_batch(
 /// [Listing 5.2] Function to compute the training and validation loss
 ///
 /// NOTE: Used for inference and so `train` param is `false` when invoking
-/// `calc_loss_batch`.
-pub fn calc_loss_loader(
-    data_loader: &GPTDataLoader,
+/// `calc_loss_batch`. Also, introduced trait bounds on DataLoader so that we
+/// can re-use for ch07 (instruction-finetuning), for which we have a different
+/// DataLoader type.
+pub fn calc_loss_loader<L: DataLoader<Item = impl Iterator<Item = Result<(Tensor, Tensor)>>>>(
+    data_loader: &L,
     model: &GPTModel,
     device: &Device,
     num_batches: Option<usize>,

--- a/src/listings/ch05.rs
+++ b/src/listings/ch05.rs
@@ -89,7 +89,7 @@ pub fn calc_loss_batch(
 /// `calc_loss_batch`. Also, introduced trait bounds on DataLoader so that we
 /// can re-use for ch07 (instruction-finetuning), for which we have a different
 /// DataLoader type.
-pub fn calc_loss_loader<L: DataLoader<Item = impl Iterator<Item = Result<(Tensor, Tensor)>>>>(
+pub fn calc_loss_loader<L: DataLoader<Batcher = impl Iterator<Item = Result<(Tensor, Tensor)>>>>(
     data_loader: &L,
     model: &GPTModel,
     device: &Device,

--- a/src/listings/ch07.rs
+++ b/src/listings/ch07.rs
@@ -438,6 +438,19 @@ pub struct InstructionDataLoader<C: CustomCollator> {
     collator: C,
 }
 
+impl<C: CustomCollator + Clone> DataLoader for InstructionDataLoader<C> {
+    type Item = InstructionDataBatcher<C>;
+
+    /// Returns a `InstructionDataBatcher` that itself provides batches over the
+    /// associated dataset.
+    fn batcher(&self) -> InstructionDataBatcher<C> {
+        let iter = InstructionDatasetIter::new(self.dataset.clone(), self.shuffle);
+        InstructionDataBatcher::new(iter, self.collator.clone())
+            .batch_size(self.batch_size)
+            .return_last_incomplete_batch(!self.drop_last)
+    }
+}
+
 impl<C: CustomCollator + Clone> InstructionDataLoader<C> {
     /// Creates a new `InstructionDataLoader`.
     ///
@@ -481,15 +494,6 @@ impl<C: CustomCollator + Clone> InstructionDataLoader<C> {
             drop_last,
             collator,
         }
-    }
-
-    /// Returns a `InstructionDataBatcher` that itself provides batches over the
-    /// associated dataset.
-    pub fn batcher(&self) -> InstructionDataBatcher<C> {
-        let iter = InstructionDatasetIter::new(self.dataset.clone(), self.shuffle);
-        InstructionDataBatcher::new(iter, self.collator.clone())
-            .batch_size(self.batch_size)
-            .return_last_incomplete_batch(!self.drop_last)
     }
 
     pub fn len(&self) -> usize {
@@ -538,7 +542,8 @@ pub fn delete_hf_cache(model_id: &str) -> Result<()> {
 /// fine-tuning is left as an example — see EG 07.10.
 pub use crate::listings::ch05::train_model_simple;
 
-// for convenience
+// for convenience we also re-export the following
+pub use crate::listings::ch02::DataLoader;
 pub use crate::listings::ch05::calc_loss_loader;
 
 #[cfg(test)]

--- a/src/listings/ch07.rs
+++ b/src/listings/ch07.rs
@@ -439,7 +439,7 @@ pub struct InstructionDataLoader<C: CustomCollator> {
 }
 
 impl<C: CustomCollator + Clone> DataLoader for InstructionDataLoader<C> {
-    type Item = InstructionDataBatcher<C>;
+    type Batcher = InstructionDataBatcher<C>;
 
     /// Returns a `InstructionDataBatcher` that itself provides batches over the
     /// associated dataset.


### PR DESCRIPTION
In order to re-use `ch05:calc_loss_loader` had to make `DataLoaders` more flexible since those used in pre-training and in instruction fine-tuning are similar, but still different. Fortunately, was able to make this work by introducing a new trait `DataLoader` that has an associated type `Batcher`. We just add some trait bound on this associated type when defining calc_loss_loader.

(ref: https://stackoverflow.com/questions/54258253/how-do-i-define-trait-bounds-on-an-associated-type#:~:text=As%20of%20Rust%201.79%2C%20you,String%3E%20%7B%20...%20%7D)