### PR TITLE
[Fix] eg 07.10 runtime error

### DIFF
--- a/src/examples/ch05.rs
+++ b/src/examples/ch05.rs
@@ -271,8 +271,8 @@ impl Example for EG04 {
         let (train_loader, val_loader) = addons::get_train_val_data_loaders(false)?;
 
         // compute train and val loss
-        let train_loss = calc_loss_loader(&train_loader, &model, vb.device(), None)?;
-        let val_loss = calc_loss_loader(&val_loader, &model, vb.device(), None)?;
+        let train_loss = calc_loss_loader(&train_loader, &model, vb.device(), None, None)?;
+        let val_loss = calc_loss_loader(&val_loader, &model, vb.device(), None, None)?;
 
         println!("Training loss {:?}", train_loss);
         println!("Validation loss {:?}", val_loss);

--- a/src/examples/ch07.rs
+++ b/src/examples/ch07.rs
@@ -1,6 +1,6 @@
 //! Examples from Chapter 7
 
-use crate::Example;
+use crate::{listings::ch05::DEFAULT_IGNORE_INDEX, Example};
 use anyhow::{anyhow, Context, Result};
 
 /// # Example usage of `download_and_load_file`
@@ -546,21 +546,33 @@ impl Example for EG09 {
         use candle_nn::{VarBuilder, VarMap};
 
         // use `download_and_load_gpt2` for gpt2-medium
-        let mut cfg = Config::gpt2_medium();
+        let mut cfg = Config::gpt2_124m();
         cfg.qkv_bias = true;
         let varmap = VarMap::new();
         let vb = VarBuilder::from_varmap(&varmap, DType::F32, &Device::cuda_if_available(0)?);
-        let model_id = "openai-community/gpt2-medium";
+        let model_id = "openai-community/gpt2";
         let model = download_and_load_gpt2(&varmap, vb.pp("model"), cfg, model_id)?;
 
         // re-use eg 07.07
         let eg07 = EG07;
         let (train_loader, val_loader, _test_loader) = eg07.main_with_return(false)?;
 
-        // compute losses
+        // // compute losses
         let num_batches = Some(5_usize);
-        let train_loss = calc_loss_loader(&train_loader, &model, vb.device(), num_batches)?;
-        let val_loss = calc_loss_loader(&val_loader, &model, vb.device(), num_batches)?;
+        let train_loss = calc_loss_loader(
+            &train_loader,
+            &model,
+            vb.device(),
+            num_batches,
+            Some(DEFAULT_IGNORE_INDEX),
+        )?;
+        let val_loss = calc_loss_loader(
+            &val_loader,
+            &model,
+            vb.device(),
+            num_batches,
+            Some(DEFAULT_IGNORE_INDEX),
+        )?;
 
         println!("Training loss: {}", train_loss);
         println!("Validation loss: {}", val_loss);

--- a/src/examples/ch07.rs
+++ b/src/examples/ch07.rs
@@ -546,11 +546,11 @@ impl Example for EG09 {
         use candle_nn::{VarBuilder, VarMap};
 
         // use `download_and_load_gpt2` for gpt2-medium
-        let mut cfg = Config::gpt2_124m();
+        let mut cfg = Config::gpt2_medium();
         cfg.qkv_bias = true;
         let varmap = VarMap::new();
         let vb = VarBuilder::from_varmap(&varmap, DType::F32, &Device::cuda_if_available(0)?);
-        let model_id = "openai-community/gpt2";
+        let model_id = "openai-community/gpt2-medium";
         let model = download_and_load_gpt2(&varmap, vb.pp("model"), cfg, model_id)?;
 
         // re-use eg 07.07

--- a/src/exercises/ch05.rs
+++ b/src/exercises/ch05.rs
@@ -373,8 +373,8 @@ impl Exercise for X5 {
         let (train_loader, val_loader) = examples::ch05::addons::get_train_val_data_loaders(false)?;
 
         // compute train and val loss
-        let train_loss = calc_loss_loader(&train_loader, &model, vb.device(), None)?;
-        let val_loss = calc_loss_loader(&val_loader, &model, vb.device(), None)?;
+        let train_loss = calc_loss_loader(&train_loader, &model, vb.device(), None, None)?;
+        let val_loss = calc_loss_loader(&val_loader, &model, vb.device(), None, None)?;
 
         println!("Training loss {:?}", train_loss);
         println!("Validation loss {:?}", val_loss);

--- a/src/listings/ch05.rs
+++ b/src/listings/ch05.rs
@@ -81,6 +81,8 @@ pub fn calc_loss_batch(
         (logits_flat, targets_flat)
     };
 
+    println!("{:?}", targets_flat.min(0)?);
+
     let loss = candle_nn::loss::cross_entropy(&logits_flat, &targets_flat)?;
     Ok(loss)
 }
@@ -96,6 +98,7 @@ pub fn calc_loss_loader<L: DataLoader<Batcher = impl Iterator<Item = Result<(Ten
     model: &GPTModel,
     device: &Device,
     num_batches: Option<usize>,
+    ignore_index: Option<i64>, // introduced for ch07 instruction finetuning
 ) -> Result<f32> {
     let mut total_loss = 0_f32;
     let mut count = 0_usize;
@@ -104,8 +107,14 @@ pub fn calc_loss_loader<L: DataLoader<Batcher = impl Iterator<Item = Result<(Ten
     match num_batches {
         None => {
             while let Some(Ok((input_batch, target_batch))) = data_batcher.next() {
-                let loss =
-                    calc_loss_batch(&input_batch, &target_batch, model, device, false, None)?;
+                let loss = calc_loss_batch(
+                    &input_batch,
+                    &target_batch,
+                    model,
+                    device,
+                    false,
+                    ignore_index,
+                )?;
                 total_loss += loss.to_scalar::<f32>()?;
                 count += 1_usize;
             }
@@ -113,8 +122,14 @@ pub fn calc_loss_loader<L: DataLoader<Batcher = impl Iterator<Item = Result<(Ten
         }
         Some(n) => {
             while let Some(Ok((input_batch, target_batch))) = data_batcher.next() {
-                let loss =
-                    calc_loss_batch(&input_batch, &target_batch, model, device, false, None)?;
+                let loss = calc_loss_batch(
+                    &input_batch,
+                    &target_batch,
+                    model,
+                    device,
+                    false,
+                    ignore_index,
+                )?;
                 total_loss += loss.to_scalar::<f32>()?;
                 count += 1_usize;
                 if count >= n {
@@ -212,8 +227,14 @@ where
             tokens_seen += input_batch.elem_count();
 
             if global_step % eval_freq == 0 {
-                let (train_loss, val_loss) =
-                    evaluate_model(model, train_loader, val_loader, device, eval_iter)?;
+                let (train_loss, val_loss) = evaluate_model(
+                    model,
+                    train_loader,
+                    val_loader,
+                    device,
+                    eval_iter,
+                    ignore_index,
+                )?;
                 train_losses.push(train_loss);
                 val_losses.push(val_loss);
                 track_tokens_seen.push(tokens_seen);
@@ -242,9 +263,10 @@ pub fn evaluate_model<L: DataLoader<Batcher = impl Iterator<Item = Result<(Tenso
     val_loader: &L,
     device: &Device,
     eval_iter: usize,
+    ignore_index: Option<i64>, // introduced for ch07 instruction finetuning
 ) -> Result<(f32, f32)> {
-    let train_loss = calc_loss_loader(train_loader, model, device, Some(eval_iter))?;
-    let val_loss = calc_loss_loader(val_loader, model, device, Some(eval_iter))?;
+    let train_loss = calc_loss_loader(train_loader, model, device, Some(eval_iter), ignore_index)?;
+    let val_loss = calc_loss_loader(val_loader, model, device, Some(eval_iter), ignore_index)?;
     Ok((train_loss, val_loss))
 }
 

--- a/src/listings/ch05.rs
+++ b/src/listings/ch05.rs
@@ -69,7 +69,7 @@ pub fn calc_loss_batch(
             .iter()
             .enumerate()
             .filter(|(_, v)| **v != ignore_val)
-            .map(|(ix, _)| ix as u8)
+            .map(|(ix, _)| ix as u32)
             .collect::<Vec<_>>();
         let keep = Tensor::new(&keep[..], device)?;
 
@@ -80,8 +80,6 @@ pub fn calc_loss_batch(
     } else {
         (logits_flat, targets_flat)
     };
-
-    println!("{:?}", targets_flat.min(0)?);
 
     let loss = candle_nn::loss::cross_entropy(&logits_flat, &targets_flat)?;
     Ok(loss)


### PR DESCRIPTION
Fixes #246 

There was a bug where when implementing ignore_index logic, I was casting the indices (`usize`) to keep in the `targets` Tensor to `u8`, which is certainly not big enough of a data type.

This PR also fixes a bug where `calc_loss_loader` was invoking `calc_loss_batch` without an `ignore_index`. The losses seem to be better now.

**Interestingly**
The above error was suppressed with cuda enabled. i.e., `cargo run --features cuda example 07.09` seemingly worked.