### PR TITLE
Rip out `Sequential` and `SequentialT` in favor of explicit sequential-like structs

### DIFF
--- a/src/examples/ch07.rs
+++ b/src/examples/ch07.rs
@@ -641,7 +641,7 @@ impl Example for EG10 {
         let (train_loader, val_loader, _test_loader) = eg07.main_with_return(false)?;
 
         // invoke training
-        let (eval_freq, eval_iter, num_epochs) = (5_usize, 5_usize, 1_usize);
+        let (eval_freq, eval_iter, num_epochs) = (5_usize, 5_usize, 2_usize);
         let optimizer = AdamW::new(
             varmap.all_vars(),
             ParamsAdamW {

--- a/src/exercises/ch04.rs
+++ b/src/exercises/ch04.rs
@@ -214,11 +214,10 @@ impl Exercise for X3 {
 
 pub mod addons {
     //! Auxiliary module for exercises::ch04
-    use crate::{
-        candle_addons::seqt,
-        listings::{
-            ch03::MultiHeadAttention,
-            ch04::{FFLayers, FeedForward, GPTModel, LayerNorm, TransformerBlock, GELU},
+    use crate::listings::{
+        ch03::MultiHeadAttention,
+        ch04::{
+            seqtransformers, FFLayers, FeedForward, GPTModel, LayerNorm, TransformerBlock, GELU,
         },
     };
     use candle_core::Result;
@@ -302,7 +301,7 @@ pub mod addons {
             let tok_emb = embedding(cfg.vocab_size, cfg.emb_dim, vb.pp("tok_emb"))?;
             let pos_emb = embedding(cfg.context_length, cfg.emb_dim, vb.pp("pos_emb"))?;
             let drop_emb = Dropout::new(cfg.drop_rate_emb);
-            let mut trf_blocks = seqt();
+            let mut trf_blocks = seqtransformers();
             for ix in 0..cfg.n_layers {
                 trf_blocks =
                     trf_blocks.add(TransformerBlock::new_v2(cfg, vb.pp(format!("trf-{}", ix)))?);

--- a/src/exercises/ch04.rs
+++ b/src/exercises/ch04.rs
@@ -218,11 +218,11 @@ pub mod addons {
         candle_addons::seqt,
         listings::{
             ch03::MultiHeadAttention,
-            ch04::{FeedForward, GPTModel, LayerNorm, TransformerBlock, GELU},
+            ch04::{FFLayers, FeedForward, GPTModel, LayerNorm, TransformerBlock, GELU},
         },
     };
     use candle_core::Result;
-    use candle_nn::{embedding, linear_b, seq, Dropout, VarBuilder};
+    use candle_nn::{embedding, linear_b, Dropout, VarBuilder};
 
     /// A second `Config` variation for Exercise 4.3 to specify individual drop rates
     #[derive(Debug, Clone, Copy)]
@@ -257,20 +257,22 @@ pub mod addons {
     /// New `FeedForward` constructor using `ConfigV2`
     impl FeedForward {
         fn new_v2(cfg: ConfigV2, vb: VarBuilder<'_>) -> Result<Self> {
-            let layers = seq()
-                .add(linear_b(
+            let layers = vec![
+                FFLayers::Linear(linear_b(
                     cfg.emb_dim,
                     4_usize * cfg.emb_dim,
                     true,
                     vb.pp("first_layer"),
-                )?)
-                .add(GELU) // you should use Activation::Gelu in actual builds
-                .add(linear_b(
+                )?),
+                FFLayers::GELU(GELU),
+                FFLayers::Linear(linear_b(
                     4_usize * cfg.emb_dim,
                     cfg.emb_dim,
                     true,
                     vb.pp("second_layer"),
-                )?);
+                )?),
+            ];
+
             FeedForward::from_fields(layers)
         }
     }

--- a/src/listings/ch04.rs
+++ b/src/listings/ch04.rs
@@ -239,6 +239,7 @@ impl Module for GELU {
     }
 }
 
+/// Explicit `FFLayers`` enum
 #[derive(Clone, Debug)]
 pub enum FFLayers {
     Linear(Linear),
@@ -255,6 +256,11 @@ impl Module for FFLayers {
 }
 
 /// [Listing 4.4] A feed forward neural network module
+///
+/// NOTE: previously used candle_nn::Sequential but this creates trait objects
+/// which lose information on the concrete type. Downcasting to the concrete
+/// type was proven difficult. Thus, opting for explicit sequence instead.
+/// The type information is necessary when wanting to implement LoRA.
 #[derive(Clone, Debug)]
 pub struct FeedForward {
     layers: Vec<FFLayers>,
@@ -450,6 +456,12 @@ impl ModuleT for TransformerBlock {
     }
 }
 
+/// Explicit sequential like type for TransformerBlock
+///
+/// NOTE: preivously used candle_nn::Sequential but this creates trait objects
+/// which lose information on the concrete type. Downcasting to the concrete
+/// type was proven difficult. Thus, opting for explicit sequence instead.
+/// The type information is necessary when wanting to implement LoRA.
 #[derive(Clone, Debug)]
 pub struct SequentialTransformers {
     layers: Vec<TransformerBlock>,


### PR DESCRIPTION
Due to `Sequential` using trait objects (i.e., `Box<dyn Module>`), downcasting to the concrete type was difficult. This becomes problematic if you want to convert a model to a LoRA enabled one, since we need to get the concrete type of the layer.

This PR:

1. Changes `FeedForward` to rely on a `Vec<FFLayer>` where `FFLayer` is an explicit enum preserving data on types.
2. Adds `SequentialTransformerBlock` that follows similar interface to `Sequential` and `SequentialT` but explicitly for `TransformerBlock`.
3. Updates `GPTModel` and necessary sub components to rely on these updated types.