### PR TITLE
`GPTModelWithLoRA`

### DIFF
--- a/src/listings/apdx_e.rs
+++ b/src/listings/apdx_e.rs
@@ -887,4 +887,22 @@ mod tests {
 
         Ok(())
     }
+
+    #[rstest]
+    fn test_gpt_model_with_lora_init(vb: VarBuilder<'_>) -> Result<()> {
+        let cfg = Config::gpt_sm_test();
+        let model = GPTModel::new(cfg, vb.pp("model"))?;
+        let alpha = 0.5_f64;
+        let rank = 2_usize;
+        let model_with_lora = GPTModelWithLoRA::from_gpt_model(model, rank, alpha, vb.pp("model"))?;
+
+        assert_eq!(model_with_lora.pos_emb.hidden_size(), cfg.emb_dim);
+        assert_eq!(model_with_lora.tok_emb.hidden_size(), cfg.emb_dim);
+        assert_eq!(model_with_lora.trf_blocks.len() as usize, cfg.n_layers);
+        assert_eq!(
+            model_with_lora.out_head.linear.weight().dims(),
+            &[cfg.vocab_size, cfg.emb_dim]
+        );
+        Ok(())
+    }
 }

--- a/src/listings/ch04.rs
+++ b/src/listings/ch04.rs
@@ -531,6 +531,7 @@ impl ModuleT for SequentialTransformers {
 }
 
 /// [Listing 4.7] The GPT model architecture implementation
+#[derive(Debug, Clone)]
 pub struct GPTModel {
     tok_emb: Embedding,
     pos_emb: Embedding,

--- a/src/listings/ch04.rs
+++ b/src/listings/ch04.rs
@@ -513,6 +513,11 @@ impl SequentialTransformers {
     pub fn is_empty(&self) -> bool {
         self.layers.is_empty()
     }
+
+    /// Accessor
+    pub fn layers(&self) -> &Vec<TransformerBlock> {
+        &self.layers
+    }
 }
 
 impl ModuleT for SequentialTransformers {
@@ -589,8 +594,24 @@ impl GPTModel {
         })
     }
 
+    pub fn drop_emb(&self) -> &Dropout {
+        &self.drop_emb
+    }
+
+    pub fn tok_emb(&self) -> &Embedding {
+        &self.tok_emb
+    }
+
     pub fn pos_emb(&self) -> &Embedding {
         &self.pos_emb
+    }
+
+    pub fn trf_blocks(&self) -> &SequentialTransformers {
+        &self.trf_blocks
+    }
+
+    pub fn final_norm(&self) -> &LayerNorm {
+        &self.final_norm
     }
 
     pub fn out_head(&self) -> &Linear {
@@ -716,7 +737,7 @@ mod tests {
     fn test_layer_norm_forward(vb: VarBuilder<'_>) -> Result<()> {
         let cfg = Config::gpt_sm_test();
         let batch_size = 2_usize;
-        let batch_example = Tensor::rand(0f32, 1f32, (batch_size, cfg.emb_dim), vb.device())?;
+        let batch_example = Tensor::rand(0f32, tolerance, (batch_size, cfg.emb_dim), vb.device())?;
         let layer_norm = LayerNorm::new(cfg.emb_dim, vb.pp("layer_norm"))?;
 
         let out_norm = layer_norm.forward(&batch_example)?;

--- a/src/listings/ch04.rs
+++ b/src/listings/ch04.rs
@@ -737,7 +737,7 @@ mod tests {
     fn test_layer_norm_forward(vb: VarBuilder<'_>) -> Result<()> {
         let cfg = Config::gpt_sm_test();
         let batch_size = 2_usize;
-        let batch_example = Tensor::rand(0f32, tolerance, (batch_size, cfg.emb_dim), vb.device())?;
+        let batch_example = Tensor::rand(0f32, 1f32, (batch_size, cfg.emb_dim), vb.device())?;
         let layer_norm = LayerNorm::new(cfg.emb_dim, vb.pp("layer_norm"))?;
 
         let out_norm = layer_norm.forward(&batch_example)?;


### PR DESCRIPTION
This is a very manual implementation of LoRA, where all Linear components are replaced by their LoRA counterparts manually. This is probably beneficial for educational purposes, but will look to use `candle-lora` to make things more automated.