### PR TITLE
`EncodedPreferenceExample` and `InstructionExample` trait

### DIFF
--- a/src/examples/ch07.rs
+++ b/src/examples/ch07.rs
@@ -79,8 +79,8 @@ impl Example for EG02 {
 
     fn main(&self) -> Result<()> {
         use crate::listings::ch07::{
-            download_and_load_file, AlpacaPromptFormatter, PromptFormatter, DATA_DIR,
-            INSTRUCTION_DATA_FILENAME, INSTRUCTION_DATA_URL,
+            download_and_load_file, AlpacaPromptFormatter, InstructionExample, PromptFormatter,
+            DATA_DIR, INSTRUCTION_DATA_FILENAME, INSTRUCTION_DATA_URL,
         };
         use std::path::Path;
 
@@ -724,7 +724,7 @@ impl Example for EG11 {
         use crate::listings::{
             ch04::{Config, GPTModel},
             ch05::{generate, text_to_token_ids, token_ids_to_text},
-            ch07::{AlpacaPromptFormatter, PromptFormatter},
+            ch07::{AlpacaPromptFormatter, InstructionExample, PromptFormatter},
         };
         use candle_core::{DType, Device, Tensor};
         use candle_nn::{VarBuilder, VarMap};
@@ -959,7 +959,8 @@ impl Example for EG15 {
     fn main(&self) -> Result<()> {
         use crate::listings::ch07::{
             load_instruction_data_from_json, query_model, AlpacaPromptFormatter,
-            InstructionResponseExample, PromptFormatter, DATA_DIR, DEFAULT_OLLAMA_API_URL,
+            InstructionExample, InstructionResponseExample, PromptFormatter, DATA_DIR,
+            DEFAULT_OLLAMA_API_URL,
         };
         use std::path::Path;
 

--- a/src/exercises/ch07.rs
+++ b/src/exercises/ch07.rs
@@ -657,8 +657,9 @@ impl Exercise for X4 {
 pub mod addons {
     //! Auxiliary module for exercises::ch07
     use crate::listings::ch07::{
-        CustomCollator, DataLoader, InstructionDataBatcher, InstructionResponseExample,
-        IterResult2, PromptFormatter, DEFAULT_IGNORE_INDEX, DEFAULT_PAD_TOKEN_ID,
+        CustomCollator, DataLoader, InstructionDataBatcher, InstructionExample,
+        InstructionResponseExample, IterResult2, PromptFormatter, DEFAULT_IGNORE_INDEX,
+        DEFAULT_PAD_TOKEN_ID,
     };
     use candle_core::{Device, Result, Tensor};
     use rand::{seq::SliceRandom, thread_rng};

--- a/src/listings/ch07/bonus.rs
+++ b/src/listings/ch07/bonus.rs
@@ -174,6 +174,7 @@ mod tests {
     use super::*;
     use anyhow::Result;
     use rstest::*;
+    use tiktoken_rs::get_bpe_from_model;
 
     #[fixture]
     fn instruction_example() -> InstructionResponseExample {
@@ -185,6 +186,22 @@ mod tests {
             input,
             output,
             model_response: None,
+        }
+    }
+
+    #[fixture]
+    fn preference_example() -> PreferenceExample {
+        let instruction = "Here is a fake instruction.".to_string();
+        let input = Some("Here is a fake input.".to_string());
+        let output = "here is a fake output.".to_string();
+        let chosen = "Here is a fake chosen.".to_string();
+        let rejected = "Here is a fake rejected.".to_string();
+        PreferenceExample {
+            instruction,
+            input,
+            output,
+            chosen,
+            rejected,
         }
     }
 
@@ -215,6 +232,26 @@ mod tests {
         minimal. Only return return the generated response and nothing else.";
 
         assert_eq!(prompt, expected);
+        Ok(())
+    }
+
+    #[rstest]
+    fn test_encoded_preference_example_from_preference_example(
+        preference_example: PreferenceExample,
+    ) -> Result<()> {
+        let tokenizer = get_bpe_from_model("gpt2")?;
+        let prompt_formatter = AlpacaPromptFormatter;
+        let encoded = EncodedPreferenceExample::from_example(
+            &preference_example,
+            &prompt_formatter,
+            &tokenizer,
+        );
+
+        let prompt = prompt_formatter.format_input(&preference_example);
+        let expected_encoded_prompt = tokenizer.encode_with_special_tokens(&prompt);
+
+        assert_eq!(encoded.prompt, expected_encoded_prompt);
+
         Ok(())
     }
 }

--- a/src/listings/ch07/bonus.rs
+++ b/src/listings/ch07/bonus.rs
@@ -34,12 +34,34 @@ impl From<InstructionResponseExample> for PreferenceExample {
 }
 
 impl PreferenceExample {
+    fn rejected(&self) -> &String {
+        &self.rejected
+    }
+
+    fn chosen(&self) -> &String {
+        &self.chosen
+    }
+
     pub fn set_rejected(&mut self, rejected: &str) {
         self.rejected = rejected.to_string();
     }
 
     pub fn set_chosen(&mut self, chosen: &str) {
         self.chosen = chosen.to_string()
+    }
+}
+
+impl InstructionExample for PreferenceExample {
+    fn instruction(&self) -> &String {
+        &self.instruction
+    }
+
+    fn input(&self) -> &Option<String> {
+        &self.input
+    }
+
+    fn output(&self) -> &String {
+        &self.output
     }
 }
 
@@ -117,16 +139,21 @@ impl EncodedPreferenceExample {
         prompt_formatter: &P,
         tokenizer: &CoreBPE,
     ) -> Self {
-        todo!()
-        // let prompt = prompt_formatter.format_input(example);
-        // rejected_response = entry["rejected"]
-        // chosen_response = entry["chosen"]
+        let prompt = prompt_formatter.format_input(example);
+        let rejected_response = example.rejected();
+        let chosen_response = example.chosen();
 
-        // prompt_tokens = tokenizer.encode(prompt)
-        // chosen_full_text = f"{prompt}\n\n### Response:\n{chosen_response}"
-        // rejected_full_text = f"{prompt}\n\n### Response:\n{rejected_response}"
-        // chosen_full_tokens = tokenizer.encode(chosen_full_text)
-        // rejected_full_tokens = tokenizer.encode(rejected_full_text)
+        let prompt_tokens = tokenizer.encode_with_special_tokens(&prompt);
+        let chosen_full_text = format!("{prompt}\n\n### Response:\n{chosen_response}");
+        let rejected_full_text = format!("{prompt}\n\n### Response:\n{rejected_response}");
+        let chosen_full_tokens = tokenizer.encode_with_special_tokens(&chosen_full_text);
+        let rejected_full_tokens = tokenizer.encode_with_special_tokens(&rejected_full_text);
+
+        Self {
+            prompt: prompt_tokens,
+            chosen: chosen_full_tokens,
+            rejected: rejected_full_tokens,
+        }
     }
 }
 

--- a/src/listings/ch07/bonus.rs
+++ b/src/listings/ch07/bonus.rs
@@ -248,9 +248,17 @@ mod tests {
         );
 
         let prompt = prompt_formatter.format_input(&preference_example);
+        let formatted_rejection =
+            format!("{prompt}\n\n### Response:\n{}", preference_example.rejected);
+        let formatted_chosen = format!("{prompt}\n\n### Response:\n{}", preference_example.chosen);
+
         let expected_encoded_prompt = tokenizer.encode_with_special_tokens(&prompt);
+        let expected_encoded_rejected = tokenizer.encode_with_special_tokens(&formatted_rejection);
+        let expected_encoded_chosen = tokenizer.encode_with_special_tokens(&formatted_chosen);
 
         assert_eq!(encoded.prompt, expected_encoded_prompt);
+        assert_eq!(encoded.rejected, expected_encoded_rejected);
+        assert_eq!(encoded.chosen, expected_encoded_chosen);
 
         Ok(())
     }

--- a/src/listings/ch07/bonus.rs
+++ b/src/listings/ch07/bonus.rs
@@ -1,12 +1,14 @@
 //! Bonus material module for Chapter 7
 
 use super::{
-    query_model, write_instruction_data_to_json, InstructionResponseExample, PromptFormatter,
+    query_model, write_instruction_data_to_json, InstructionExample, InstructionResponseExample,
+    PromptFormatter,
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, NoneAsEmptyString};
 use std::path::Path;
+use tiktoken_rs::CoreBPE;
 use tqdm::tqdm;
 
 #[serde_as]
@@ -100,6 +102,43 @@ pub fn generate_preference_dataset<P: PromptFormatter, T: AsRef<Path>>(
 
     Ok(())
 }
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct EncodedPreferenceExample {
+    prompt: Vec<u32>,
+    chosen: Vec<u32>,
+    rejected: Vec<u32>,
+}
+
+impl EncodedPreferenceExample {
+    #[allow(unused_variables)]
+    pub fn from_example<P: PromptFormatter>(
+        example: &PreferenceExample,
+        prompt_formatter: &P,
+        tokenizer: &CoreBPE,
+    ) -> Self {
+        todo!()
+        // let prompt = prompt_formatter.format_input(example);
+        // rejected_response = entry["rejected"]
+        // chosen_response = entry["chosen"]
+
+        // prompt_tokens = tokenizer.encode(prompt)
+        // chosen_full_text = f"{prompt}\n\n### Response:\n{chosen_response}"
+        // rejected_full_text = f"{prompt}\n\n### Response:\n{rejected_response}"
+        // chosen_full_tokens = tokenizer.encode(chosen_full_text)
+        // rejected_full_tokens = tokenizer.encode(rejected_full_text)
+    }
+}
+
+#[allow(dead_code)]
+pub struct PreferenceDataset_ {
+    data: Vec<PreferenceExample>,
+    encoded_texts: Vec<Vec<u32>>,
+}
+
+/// Implementing a `PreferenceDataset`
+#[derive(Clone)]
+pub struct PreferenceDataset;
 
 #[cfg(test)]
 mod tests {

--- a/src/listings/ch07/mod.rs
+++ b/src/listings/ch07/mod.rs
@@ -53,24 +53,33 @@ impl InstructionResponseExample {
         }
     }
 
-    pub fn instruction(&self) -> &String {
-        &self.instruction
-    }
-
-    pub fn input(&self) -> &Option<String> {
-        &self.input
-    }
-
-    pub fn output(&self) -> &String {
-        &self.output
-    }
-
     pub fn model_response(&self) -> &Option<String> {
         &self.model_response
     }
 
     pub fn set_model_response(&mut self, model_response: &str) {
         self.model_response = Some(model_response.to_string());
+    }
+}
+
+// Marker trait for instruction example
+pub trait InstructionExample {
+    fn instruction(&self) -> &String;
+    fn input(&self) -> &Option<String>;
+    fn output(&self) -> &String;
+}
+
+impl InstructionExample for InstructionResponseExample {
+    fn instruction(&self) -> &String {
+        &self.instruction
+    }
+
+    fn input(&self) -> &Option<String> {
+        &self.input
+    }
+
+    fn output(&self) -> &String {
+        &self.output
     }
 }
 
@@ -105,7 +114,7 @@ pub fn download_and_load_file<P: AsRef<Path>>(
 
 /// Prompt trait introduced for Excercise 7.1 to extend `format_input` to other prompt styles
 pub trait PromptFormatter {
-    fn format_input(&self, entry: &InstructionResponseExample) -> String;
+    fn format_input<T: InstructionExample>(&self, entry: &T) -> String;
 }
 
 /// Alpaca prompt formatter type [used in Listing 7.2]
@@ -113,13 +122,13 @@ pub struct AlpacaPromptFormatter;
 
 impl PromptFormatter for AlpacaPromptFormatter {
     /// [Listing 7.2] Implementing the prompt formatting function
-    fn format_input(&self, entry: &InstructionResponseExample) -> String {
+    fn format_input<T: InstructionExample>(&self, entry: &T) -> String {
         let instruction_text = format!(
             "Below is an instruction that describes a task. Write a response that \
             appropriately completes the request.\n\n### Instruction:\n{}",
-            entry.instruction
+            entry.instruction()
         );
-        let input_text = if let Some(inp) = &entry.input {
+        let input_text = if let Some(inp) = &entry.input() {
             format!("\n\n### Input:\n{}", inp)
         } else {
             String::default()
@@ -131,7 +140,7 @@ impl PromptFormatter for AlpacaPromptFormatter {
 pub struct Phi3PromptFormatter;
 
 impl PromptFormatter for Phi3PromptFormatter {
-    fn format_input(&self, entry: &InstructionResponseExample) -> String {
+    fn format_input<T: InstructionExample>(&self, entry: &T) -> String {
         match entry.input() {
             Some(input_str) => format!(
                 "<|user|>\n{}\n{}\n\n<|assistant|>\n{}",

--- a/src/listings/ch07/mod.rs
+++ b/src/listings/ch07/mod.rs
@@ -150,15 +150,11 @@ impl PromptFormatter for Phi3PromptFormatter {
 
 /// [Listing 7.3] Partitioning the dataset
 #[allow(unused_variables)]
-pub fn partition_data(
-    data: Vec<InstructionResponseExample>,
+pub fn partition_data<T: Clone>(
+    data: Vec<T>,
     train_frac: f32,
     validation_frac: f32,
-) -> anyhow::Result<(
-    Vec<InstructionResponseExample>,
-    Vec<InstructionResponseExample>,
-    Vec<InstructionResponseExample>,
-)> {
+) -> anyhow::Result<(Vec<T>, Vec<T>, Vec<T>)> {
     let train_portion = (data.len() as f32 * train_frac) as usize;
     let val_portion = (data.len() as f32 * validation_frac) as usize;
 


### PR DESCRIPTION
Introduces:

- InstructionExample trait
- EncodedPreferenceExample
- modifies `format_input` to take generic T: InstructionExample
- modifies `partition_data` to take generic T: Clone