### PR TITLE
Fix sample_create_vocab function to use String keys and i32 values in the vocabulary HashMap

### DIFF
--- a/src/listings/ch02.rs
+++ b/src/listings/ch02.rs
@@ -20,17 +20,17 @@ pub fn sample_read_text(verbose: bool) -> Result<String> {
 }
 
 /// [Listing 2.2] Creating a vocabulary
-pub fn sample_create_vocab() -> Result<HashMap<i32, String>> {
+pub fn sample_create_vocab() -> Result<HashMap<String, i32>> {
     let raw_text = sample_read_text(false)?;
     let re = Regex::new(r#"([,.?_!"()']|--|\s)"#).unwrap();
     let mut preprocessed: Vec<&str> = re.split(&raw_text[..]).map(|x| x.unwrap()).collect();
     preprocessed.sort();
 
-    let vocab: HashMap<i32, String> = HashMap::from_iter(
+    let vocab: HashMap<String, i32> = HashMap::from_iter(
         preprocessed
             .iter()
             .enumerate()
-            .map(|(idx, el)| (idx as i32, el.to_string())),
+            .map(|(idx, el)| (el.to_string(), idx as i32)),
     );
     Ok(vocab)
 }


### PR DESCRIPTION
- From listings 2.2 in Chapter 2, the return value of the HashMap is reversed. So I modified the return value of the function.