### PR TITLE
Fix build on current stable Rust: bump ethnum to 1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"


### PR DESCRIPTION
## Problem

`main` and **every open Dependabot PR** have been failing CI since ~2026-07-16. The failure is unrelated to any of the dependency bumps:

```
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
  --> ethnum-1.5.0/src/error.rs:16:14
   |
16 |     unsafe { mem::transmute(()) }
   |              ^^^^^^^^^^^^^^
   = note: source type: `()` (0 bits)
   = note: target type: `TryFromIntError` (8 bits)
```

`ethnum` 1.5.0 fabricates `TryFromIntError` and `ParseIntError` values by transmuting from `()`. `TryFromIntError` stopped being a zero-sized type in current stable rustc, so the transmute is now a hard error. `ethnum` is pulled in transitively via `polars-arrow`, so it breaks `cargo clippy`, `cargo build`, and `cargo test` for the whole crate.

## Fix

`cargo update -p ethnum --precise 1.5.3`. Upstream 1.5.3 removes the transmute hack entirely, constructing the errors safely in `const fn`s instead (1.5.1 and 1.5.2 still carry the bug).

Lockfile-only change — no source or manifest changes.

## Verification

Run locally against `rustc 1.97.1`, the same stable CI resolves to:

| Check | Result |
| --- | --- |
| `cargo clippy` | passes (pre-existing warnings only) |
| `cargo build` | passes |
| `cargo test --lib` | 90 passed, 0 failed |
| `cargo test --doc -- --test-threads=2` | 30 passed, 0 failed |

This needs to land before any of the open Dependabot PRs can go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)